### PR TITLE
Change variable references to default ruby literal style

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@ case node['platform_family']
 when 'rhel', 'fedora'
 
     remote_file "#{Chef::Config[:file_cache_path]}/swookiee.rpm" do
-        source "https://github.com/swookiee/swookiee-packages/releases/download/v#{node.swookiee.rpm_version}/swookiee-#{node.swookiee.version}-v#{node.swookiee.rpm_version}.noarch.rpm"
+        source "https://github.com/swookiee/swookiee-packages/releases/download/v#{node[:swookiee][:rpm_version]}/swookiee-#{node[:swookiee][:version]}-v#{node[:swookiee][:rpm_version]}.noarch.rpm"
         action :create
     end
 

--- a/templates/default/swookiee.erb
+++ b/templates/default/swookiee.erb
@@ -2,10 +2,10 @@
 ## Copy this to /etc/default/swookiee
 
 # Memory settings
-JVM_OPTS="<%= node.swookiee.jvm_opts %>"
+JVM_OPTS="<%= node[:swookiee][:jvm_opts] %>"
 
 # Drop In Folder
-DROP_IN="-Dfelix.fileinstall.dir=<%= node.swookiee.dropin_location %>"
+DROP_IN="-Dfelix.fileinstall.dir=<%= node[:swookiee][:dropin_location] %>"
 
 # Start process with non-default priority (default 'nice' priorities -20 to 19)
-PROCESS_PRIORITY=<%= node.swookiee.process_priority %>
+PROCESS_PRIORITY=<%= node[:swookiee][:process_priority] %>


### PR DESCRIPTION
Using most recent chef version these variables could not be interpolated any more.